### PR TITLE
Fix: Services list ps format references non-existent displayName field and fails to reference description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- [#12](https://github.com/saas-rs/cli/issues/12) Services list ps format references non-existent displayName field and fails to reference description
 - [#9](https://github.com/saas-rs/cli/issues/9) Crate fails to hyperlink to this Git repo
 
 ## [0.1.4] - 2025-05-10

--- a/src/cmd/list/services.rs
+++ b/src/cmd/list/services.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use polars::prelude::*;
 use std::io::Cursor;
 
-pub const PS_COLUMNS: &[&str] = &["id", "name", "displayName", "tags", "visible"];
+pub const PS_COLUMNS: &[&str] = &["id", "name", "tags", "description"];
 
 #[derive(Debug, Parser)]
 pub struct Opts {


### PR DESCRIPTION
Fixes #12.