### PR TITLE
Fix: After receiving a generate response patch, don't try to apply the patch if there were no changes and the file is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SaaS RS :: CLI Changelog
 
+## [Unreleased]
+### Fixed
+- [#80](https://github.com/saas-rs/cli/issues/80) After receiving a generate response patch, don't try to apply the patch if there were no changes and the file is empty
+
 ## [0.3.5] - 2025-09-19
 ### Changed
 - [#78](https://github.com/saas-rs/cli/issues/78) Upgrade Rust from 1.86.0 → 1.88.0

--- a/src/cmd/generate/do_generate.rs
+++ b/src/cmd/generate/do_generate.rs
@@ -52,6 +52,12 @@ pub async fn do_generate(req: GenerateRequest) -> Result<(), Box<dyn std::error:
     // Apply a patch, if it was received
     let patch_path = format!("{}/my.patch", tempdir.path().display());
     if std::fs::exists(&patch_path)? {
+        if let Ok(metadata) = std::fs::metadata(&patch_path) {
+            if metadata.len() == 0 {
+                eprintln!("No changes to the workspace were necessary");
+                return Ok(());
+            }
+        }
         let _output = Command::new("git").arg("apply").arg(patch_path).output()?;
         eprintln!("Patch applied to local workspace");
     }


### PR DESCRIPTION
Fixes #80.